### PR TITLE
Remove check of right child start time when searching for intersections

### DIFF
--- a/period_collection.go
+++ b/period_collection.go
@@ -421,7 +421,7 @@ func (pc *PeriodCollection) intersecting(query Period, root *node, results *[]in
 	if root.period.Intersects(query) {
 		*results = append(*results, root.contents)
 	}
-	if !root.right.leaf && (root.right.maxEnd.After(query.Start) || root.right.maxEnd.IsZero()) && root.right.period.Start.Before(query.End) {
+	if !root.right.leaf && (root.right.maxEnd.After(query.Start) || root.right.maxEnd.IsZero()) {
 		pc.intersecting(query, root.right, results)
 	}
 }
@@ -447,7 +447,7 @@ func (pc *PeriodCollection) anyIntersecting(query Period, root *node) bool {
 	if !root.left.leaf && (root.left.maxEnd.After(query.Start) || root.left.maxEnd.IsZero()) {
 		return pc.anyIntersecting(query, root.left)
 	}
-	if !root.right.leaf && (root.right.maxEnd.After(query.Start) || root.right.maxEnd.IsZero()) && root.right.period.Start.Before(query.End) {
+	if !root.right.leaf && (root.right.maxEnd.After(query.Start) || root.right.maxEnd.IsZero()) {
 		return pc.anyIntersecting(query, root.right)
 	}
 	return false


### PR DESCRIPTION
`root.right` is not the in order successor of root so the removed check was not comparing the correct node start time.

I did not add a replacement because finding the in order successor requires traversing the tree and I'm not yet sure that there's a significant performance improvement to trying to "short circuit" the search there.

