### PR TITLE
Add IsZero check to Period to check if the period represents zero duration

### DIFF
--- a/periodic.go
+++ b/periodic.go
@@ -145,6 +145,12 @@ func (p Period) Equals(other Period) bool {
 	return p.Start.Equal(other.Start) && p.End.Equal(other.End)
 }
 
+// IsZero returns whether the period encompasses no time; in other words, the time difference between the start and end
+// of the period is zero.
+func (p Period) IsZero() bool {
+	return p.Start.Sub(p.End) == 0
+}
+
 // MaxTime returns the maximum of the provided times
 func MaxTime(times ...time.Time) time.Time {
 	if len(times) == 0 {

--- a/periodic_test.go
+++ b/periodic_test.go
@@ -619,3 +619,26 @@ func TestMonStartToSunStart(t *testing.T) {
 		})
 	}
 }
+
+func TestPeriod_IsZero(t *testing.T) {
+	tests := []struct {
+		name    string
+		p       Period
+		outcome bool
+	}{
+		{
+			"period where start and end are not equal is not zero",
+			Period{Start: time.Unix(1, 0), End: time.Unix(5, 0)},
+			false,
+		}, {
+			"period where start and end are equal is zero",
+			Period{Start: time.Unix(1, 0), End: time.Unix(1, 0)},
+			true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.outcome, test.p.IsZero())
+		})
+	}
+}


### PR DESCRIPTION
I was debating whether to name this method `IsZeroDuration`, but settled on `IsZero` because a time period that doesn't encompass any time is the same no matter when it starts/ends.