### PR TITLE
Convert update to upsert, delete with no key is a no-op

### DIFF
--- a/period_collection.go
+++ b/period_collection.go
@@ -63,19 +63,19 @@ func NewPeriodCollection() *PeriodCollection {
 // Insert adds a new period into the collection. The key parameter is a unique identifier that must be supplied
 // when inserting a new period. contents is an arbitrary object associated with the period inserted. If a period
 // already exists with the given key, an error will be returned.
-func (pc *PeriodCollection) Insert(period Period, key, contents interface{}) error {
+func (pc *PeriodCollection) Insert(key interface{}, period Period, contents interface{}) error {
 	pc.mutex.Lock()
 	defer pc.mutex.Unlock()
 	if _, ok := pc.nodes[key]; ok {
 		return fmt.Errorf("period with key %v already exists", key)
 	}
-	pc.insert(period, key, contents)
+	pc.insert(key, period, contents)
 	return nil
 }
 
 // insert is the internal function that adds a new red node to the tree. Note this function does not lock the mutex,
 // that must be done by the caller.
-func (pc *PeriodCollection) insert(period Period, key, contents interface{}) {
+func (pc *PeriodCollection) insert(key interface{}, period Period, contents interface{}) {
 	inserted := newNode(period, key, contents, red)
 	pc.nodes[key] = inserted
 	if pc.root == nil || pc.root.leaf {
@@ -363,7 +363,7 @@ func (pc *PeriodCollection) Update(key interface{}, newPeriod Period, newContent
 	defer pc.mutex.Unlock()
 	oldNode, ok := pc.nodes[key]
 	if !ok {
-		pc.insert(newPeriod, key, newContents)
+		pc.insert(key, newPeriod, newContents)
 		return
 	}
 	if oldNode.period.Equals(newPeriod) {
@@ -373,7 +373,7 @@ func (pc *PeriodCollection) Update(key interface{}, newPeriod Period, newContent
 	}
 	// if the period has changed, delete the old node and insert a new one
 	pc.delete(oldNode)
-	pc.insert(newPeriod, key, newContents)
+	pc.insert(key, newPeriod, newContents)
 }
 
 // ContainsTime returns whether there is any stored period that contains the supplied time.

--- a/period_collection.go
+++ b/period_collection.go
@@ -374,7 +374,6 @@ func (pc *PeriodCollection) Update(key interface{}, newPeriod Period, newContent
 	// if the period has changed, delete the old node and insert a new one
 	pc.delete(oldNode)
 	pc.insert(newPeriod, key, newContents)
-	return
 }
 
 // ContainsTime returns whether there is any stored period that contains the supplied time.

--- a/period_collection_test.go
+++ b/period_collection_test.go
@@ -501,8 +501,8 @@ func TestPeriodCollection_successor(t *testing.T) {
 
 func TestPeriodCollection_Delete(t *testing.T) {
 	tests := []struct {
-		name   string
-		key    interface{}
+		name string
+		key  interface{}
 	}{
 		{
 			"deleting a node should also remove it from the external map",

--- a/period_collection_test.go
+++ b/period_collection_test.go
@@ -261,7 +261,7 @@ func TestPeriodCollection_Insert(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			pc := test.setupTree()
 			for _, i := range test.insertions {
-				err := pc.Insert(i.period, i.key, nil)
+				err := pc.Insert(i.key, i.period, nil)
 				if i.expectErr {
 					assert.Error(t, err)
 				} else {
@@ -1525,7 +1525,7 @@ func TestPeriodCollection_ContainsTime(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			pc := NewPeriodCollection()
 			for i, p := range test.periods {
-				require.NoError(t, pc.Insert(p, i, nil))
+				require.NoError(t, pc.Insert(i, p, nil))
 			}
 			assert.Equal(t, test.expectedOutcome, pc.ContainsTime(test.query))
 		})
@@ -1548,7 +1548,7 @@ func TestPeriodCollection_Intersecting(t *testing.T) {
 	}
 	pc := NewPeriodCollection()
 	for i, n := range nodes {
-		require.NoError(t, pc.Insert(n.period, i, n.contents))
+		require.NoError(t, pc.Insert(i, n.period, n.contents))
 	}
 	tests := []struct {
 		name             string
@@ -1821,7 +1821,7 @@ func TestPeriodCollection_AnyIntersecting(t *testing.T) {
 				}
 				pc := NewPeriodCollection()
 				for i, p := range periods {
-					require.NoError(t, pc.Insert(p, i, nil))
+					require.NoError(t, pc.Insert(i, p, nil))
 				}
 				return pc
 			},
@@ -1837,7 +1837,7 @@ func TestPeriodCollection_AnyIntersecting(t *testing.T) {
 				}
 				pc := NewPeriodCollection()
 				for i, p := range periods {
-					require.NoError(t, pc.Insert(p, i, nil))
+					require.NoError(t, pc.Insert(i, p, nil))
 				}
 				return pc
 			},
@@ -1849,10 +1849,11 @@ func TestPeriodCollection_AnyIntersecting(t *testing.T) {
 				pc := NewPeriodCollection()
 				require.NoError(
 					t, pc.Insert(
+						1,
 						NewPeriod(
 							time.Date(2018, 12, 6, 0, 0, 0, 0, time.UTC),
 							time.Date(2018, 12, 10, 0, 0, 0, 0, time.UTC),
-						), 1, nil))
+						), nil))
 				return pc
 			},
 			NewPeriod(time.Date(2018, 12, 1, 0, 0, 0, 0, time.UTC), time.Date(2018, 12, 2, 0, 0, 0, 0, time.UTC)),
@@ -1872,7 +1873,7 @@ func TestPeriodCollection_AnyIntersecting(t *testing.T) {
 				}
 				pc := NewPeriodCollection()
 				for i, p := range periods {
-					require.NoError(t, pc.Insert(p, i, nil))
+					require.NoError(t, pc.Insert(i, p, nil))
 				}
 				return pc
 			},
@@ -1888,7 +1889,7 @@ func TestPeriodCollection_AnyIntersecting(t *testing.T) {
 				}
 				pc := NewPeriodCollection()
 				for i, p := range periods {
-					require.NoError(t, pc.Insert(p, i, nil))
+					require.NoError(t, pc.Insert(i, p, nil))
 				}
 				return pc
 			},
@@ -1904,7 +1905,7 @@ func TestPeriodCollection_AnyIntersecting(t *testing.T) {
 				}
 				pc := NewPeriodCollection()
 				for i, p := range periods {
-					require.NoError(t, pc.Insert(p, i, nil))
+					require.NoError(t, pc.Insert(i, p, nil))
 				}
 				return pc
 			},
@@ -1920,7 +1921,7 @@ func TestPeriodCollection_AnyIntersecting(t *testing.T) {
 				}
 				pc := NewPeriodCollection()
 				for i, p := range periods {
-					require.NoError(t, pc.Insert(p, i, nil))
+					require.NoError(t, pc.Insert(i, p, nil))
 				}
 				return pc
 			},
@@ -2034,7 +2035,7 @@ func TestPeriodCollection_DeleteOnCondition(t *testing.T) {
 		}
 		pc := NewPeriodCollection()
 		for _, n := range nodes {
-			require.NoError(t, pc.Insert(n.period, n.contents, n.contents))
+			require.NoError(t, pc.Insert(n.contents, n.period, n.contents))
 		}
 		return pc
 	}


### PR DESCRIPTION
In `PeriodCollection`:
* Delete if a key doesn't exist is a no-op which matches the behavior of `delete` from a Go map.
* `Update` is now an upsert because checking if a key existed before deciding to update or insert caused a lot of verbosity and repeated code downstream.
* The ordering of parameters in `Insert` matches `Update`