### PR TITLE
Fix Intersects to handle equivalent start/end times

### DIFF
--- a/period_collection_test.go
+++ b/period_collection_test.go
@@ -1582,7 +1582,7 @@ func TestPeriodCollection_Intersecting(t *testing.T) {
 			func() *PeriodCollection {
 				return pc
 			},
-			NewPeriod(time.Date(2018, 12, 5, 12, 0, 0, 0, time.UTC), time.Date(2018, 12, 7, 0, 0, 0, 0, time.UTC)),
+			NewPeriod(time.Date(2018, 12, 5, 12, 0, 0, 0, time.UTC), time.Date(2018, 12, 6, 0, 0, 0, 0, time.UTC)),
 			[]interface{}{"a"},
 		}, {
 			"2018-12-05 12:00 - 2018-12-05 14:00 does not intersect",

--- a/periodic.go
+++ b/periodic.go
@@ -70,13 +70,15 @@ func NewPeriod(start, end time.Time) Period {
 // the time period is unbounded on the end.
 func (p Period) Intersects(other Period) bool {
 	if p.End.IsZero() && !other.End.IsZero() {
-		return p.Start.Before(other.End)
+		return p.Start.Before(other.End) || p.Start.Equal(p.End)
 	}
 	if !p.End.IsZero() && other.End.IsZero() {
-		return other.Start.Before(p.End)
+		return other.Start.Before(p.End) || other.Start.Equal(p.End)
 	}
 	// Calculate max(starts) < min(ends)
-	return MaxTime(p.Start, other.Start).Before(MinTime(p.End, other.End))
+	maxStart := MaxTime(p.Start, other.Start)
+	minEnd := MinTime(p.End, other.End)
+	return maxStart.Before(minEnd) || maxStart.Equal(minEnd)
 }
 
 // Contains returns true if the other time period is contained within the Period

--- a/periodic_test.go
+++ b/periodic_test.go
@@ -84,6 +84,26 @@ func TestPeriod_Intersects(t *testing.T) {
 			false,
 			p,
 			NewPeriod(p.End.Add(time.Second), time.Time{}),
+		}, {
+			"True when end is equal to other start and other end is unbounded",
+			true,
+			p,
+			NewPeriod(p.End, time.Time{}),
+		}, {
+			"True when start is equal to other end and other start is unbounded",
+			true,
+			p,
+			NewPeriod(time.Time{}, p.Start),
+		}, {
+			"True when start is equal to other end and both periods are bounded",
+			true,
+			p,
+			NewPeriod(p.Start.Add(-time.Hour), p.Start),
+		}, {
+			"True when end is equal to other start and both periods are bounded",
+			true,
+			p,
+			NewPeriod(p.End, p.End.Add(time.Hour)),
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
A period with an end time equal to the start time of another period should return intersecting.