### PR TITLE
Add implementation for ContainsTime

### DIFF
--- a/period_collection.go
+++ b/period_collection.go
@@ -406,15 +406,15 @@ func (pc *PeriodCollection) update(key interface{}, newPeriod Period, newContent
 	pc.insert(key, newPeriod, newContents)
 }
 
-// ContainsTime returns whether there is any stored period that contains the supplied time.
-func (pc *PeriodCollection) ContainsTime(time time.Time) bool {
+// AnyContainsTime returns whether there is any stored period that contains the supplied time.
+func (pc *PeriodCollection) AnyContainsTime(time time.Time) bool {
 	pc.mutex.RLock()
 	defer pc.mutex.RUnlock()
-	return pc.containsTime(pc.root, time)
+	return pc.anyContainsTime(pc.root, time)
 }
 
-// containsTime is the internal function that recursively searches the tree for the supplied time.
-func (pc *PeriodCollection) containsTime(root *node, time time.Time) bool {
+// anyContainsTime is the internal function that recursively searches the tree for the supplied time.
+func (pc *PeriodCollection) anyContainsTime(root *node, time time.Time) bool {
 	if root.leaf {
 		return false
 	}
@@ -422,9 +422,9 @@ func (pc *PeriodCollection) containsTime(root *node, time time.Time) bool {
 		return true
 	}
 	if !root.left.leaf && (root.left.maxEnd.After(time) || root.left.maxEnd.IsZero()) {
-		return pc.containsTime(root.left, time)
+		return pc.anyContainsTime(root.left, time)
 	}
-	return pc.containsTime(root.right, time)
+	return pc.anyContainsTime(root.right, time)
 }
 
 // Intersecting returns the contents of all objects whose associated periods intersect the supplied query period.

--- a/period_collection.go
+++ b/period_collection.go
@@ -435,36 +435,36 @@ type traverser interface {
 	selectNode(node *node) bool
 }
 
-// ContainsTimeTraverser implements the traverser interface and is used to return the contents of
+// containsTimeTraverser implements the traverser interface and is used to return the contents of
 // all objects whose associated periods contain the supplied time.
-type ContainsTimeTraverser struct {
+type containsTimeTraverser struct {
 	time time.Time
 }
 
-func (ct ContainsTimeTraverser) branchCondition(node *node) bool {
+func (ct containsTimeTraverser) branchCondition(node *node) bool {
 	return node.maxEnd.After(ct.time) || node.maxEnd.IsZero()
 }
 
-func (ct ContainsTimeTraverser) selectNode(node *node) bool {
+func (ct containsTimeTraverser) selectNode(node *node) bool {
 	return node.period.ContainsTime(ct.time, false)
 }
 
 // ContainsTime will find and return the contents of all objects in a periodic collection that contain the given time.
 func (pc *PeriodCollection) ContainsTime(time time.Time) []interface{} {
-	return pc.traverse(ContainsTimeTraverser{time: time})
+	return pc.traverse(containsTimeTraverser{time: time})
 }
 
-// IntersectTraverser implements the traverser interface and is used to find and return the contents of
+// intersectTraverser implements the traverser interface and is used to find and return the contents of
 // all objects whose associated periods intersect the query period.
-type IntersectTraverser struct {
+type intersectTraverser struct {
 	query Period
 }
 
-func (it IntersectTraverser) branchCondition(node *node) bool {
+func (it intersectTraverser) branchCondition(node *node) bool {
 	return node.maxEnd.After(it.query.Start) || node.maxEnd.IsZero()
 }
 
-func (it IntersectTraverser) selectNode(node *node) bool {
+func (it intersectTraverser) selectNode(node *node) bool {
 	return node.period.Intersects(it.query)
 }
 
@@ -472,7 +472,7 @@ func (it IntersectTraverser) selectNode(node *node) bool {
 // Period intersection is inclusive on the start time but exclusive on the end time. The results returned by
 // Intersecting are sorted in ascending order by the associated period's start time.
 func (pc *PeriodCollection) Intersecting(query Period) []interface{} {
-	return pc.traverse(IntersectTraverser{query: query})
+	return pc.traverse(intersectTraverser{query: query})
 }
 
 // traverse will traverse a periodic collection return the contents of all objects that satisfy a condition defined

--- a/period_collection.go
+++ b/period_collection.go
@@ -6,7 +6,7 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software
+// Unless required by selectNode law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
@@ -427,31 +427,80 @@ func (pc *PeriodCollection) anyContainsTime(root *node, time time.Time) bool {
 	return pc.anyContainsTime(root.right, time)
 }
 
+// traverser is an interface used for traversing a periodic collection and returning the contents of all objects that
+// satisfy the defined condition. branchCondition is used to determine whether the branch at the given node should
+// be traversed. selectNode defines the condition that a node must satisfy to be selected and returned.
+type traverser interface {
+	branchCondition(node *node) bool
+	selectNode(node *node) bool
+}
+
+// ContainsTimeTraverser implements the traverser interface and is used to return the contents of
+// all objects whose associated periods contain the supplied time.
+type ContainsTimeTraverser struct {
+	time time.Time
+}
+
+func (ct ContainsTimeTraverser) branchCondition(node *node) bool {
+	return node.maxEnd.After(ct.time) || node.maxEnd.IsZero()
+}
+
+func (ct ContainsTimeTraverser) selectNode(node *node) bool {
+	return node.period.ContainsTime(ct.time, false)
+}
+
+// ContainsTime will find and return the contents of all objects in a periodic collection that contain the given time.
+func (pc *PeriodCollection) ContainsTime(time time.Time) []interface{} {
+	return pc.traverse(ContainsTimeTraverser{time: time})
+}
+
+// IntersectTraverser implements the traverser interface and is used to find and return the contents of
+// all objects whose associated periods intersect the query period.
+type IntersectTraverser struct {
+	query Period
+}
+
+func (it IntersectTraverser) branchCondition(node *node) bool {
+	return node.maxEnd.After(it.query.Start) || node.maxEnd.IsZero()
+}
+
+func (it IntersectTraverser) selectNode(node *node) bool {
+	return node.period.Intersects(it.query)
+}
+
 // Intersecting returns the contents of all objects whose associated periods intersect the supplied query period.
 // Period intersection is inclusive on the start time but exclusive on the end time. The results returned by
 // Intersecting are sorted in ascending order by the associated period's start time.
 func (pc *PeriodCollection) Intersecting(query Period) []interface{} {
+	return pc.traverse(IntersectTraverser{query: query})
+}
+
+// traverse will traverse a periodic collection return the contents of all objects that satisfy a condition defined
+// by the traverser
+func (pc *PeriodCollection) traverse(traverser traverser) []interface{} {
 	pc.mutex.RLock()
 	defer pc.mutex.RUnlock()
 	results := make([]interface{}, 0, len(pc.nodes))
 	if pc.root.leaf {
 		return results
 	}
-	pc.intersecting(query, pc.root, &results)
+	pc.traverseRecursive(traverser, pc.root, &results)
 	return results
 }
 
-// intersecting is the internal function that recursively searches the tree and adds all node contents to results.
+// traverseRecursive is the recursive step of traverse that will determine which branches should be traversed in the
+// periodic collection based on the supplied conditions in the traverser, and will return the contents of all objects
+// that satisfy the condition defined by the traverser.
 // This method traverses the tree in-order, meaning that the results returned are sorted by start time ascending.
-func (pc *PeriodCollection) intersecting(query Period, root *node, results *[]interface{}) {
-	if !root.left.leaf && (root.left.maxEnd.After(query.Start) || root.left.maxEnd.IsZero()) {
-		pc.intersecting(query, root.left, results)
+func (pc *PeriodCollection) traverseRecursive(traverser traverser, root *node, results *[]interface{}) {
+	if !root.left.leaf && traverser.branchCondition(root.left) {
+		pc.traverseRecursive(traverser, root.left, results)
 	}
-	if root.period.Intersects(query) {
+	if traverser.selectNode(root) {
 		*results = append(*results, root.contents)
 	}
-	if !root.right.leaf && (root.right.maxEnd.After(query.Start) || root.right.maxEnd.IsZero()) {
-		pc.intersecting(query, root.right, results)
+	if !root.right.leaf && traverser.branchCondition(root.right) {
+		pc.traverseRecursive(traverser, root.right, results)
 	}
 }
 

--- a/period_collection.go
+++ b/period_collection.go
@@ -6,7 +6,7 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by selectNode law or agreed to in writing, software
+// Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and

--- a/period_collection_test.go
+++ b/period_collection_test.go
@@ -6,7 +6,7 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software
+// Unless required by selectNode law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
@@ -1463,7 +1463,7 @@ func TestPeriodCollection_deleteRepairCase4(t *testing.T) {
 	}
 }
 
-func TestPeriodCollection_ContainsTime(t *testing.T) {
+func TestPeriodCollection_AnyContainsTime(t *testing.T) {
 	periods := []Period{
 		NewPeriod(time.Date(2018, 12, 6, 0, 0, 0, 0, time.UTC), time.Date(2018, 12, 7, 0, 0, 0, 0, time.UTC)),
 		NewPeriod(time.Date(2018, 12, 7, 0, 0, 0, 0, time.UTC), time.Date(2018, 12, 8, 0, 0, 0, 0, time.UTC)),
@@ -1528,6 +1528,70 @@ func TestPeriodCollection_ContainsTime(t *testing.T) {
 				require.NoError(t, pc.Insert(i, p, nil))
 			}
 			assert.Equal(t, test.expectedOutcome, pc.AnyContainsTime(test.query))
+		})
+	}
+}
+
+func TestPeriodCollection_ContainsTime(t *testing.T) {
+	nodes := []struct {
+		contents string
+		period   Period
+	}{
+		{"a", NewPeriod(time.Date(2018, 12, 5, 0, 0, 0, 0, time.UTC), time.Date(2018, 12, 7, 0, 0, 0, 0, time.UTC))},
+		{"b", NewPeriod(time.Date(2018, 12, 7, 0, 0, 0, 0, time.UTC), time.Date(2018, 12, 8, 0, 0, 0, 0, time.UTC))},
+		{"c", NewPeriod(time.Date(2018, 12, 7, 12, 0, 0, 0, time.UTC), time.Time{})},
+	}
+	pc := NewPeriodCollection()
+	for i, n := range nodes {
+		require.NoError(t, pc.Insert(i, n.period, n.contents))
+	}
+	tests := []struct {
+		name             string
+		setupCollection  func() *PeriodCollection
+		time             time.Time
+		expectedContents []interface{}
+	}{
+		{
+			"2018-12-05 00:00 contained in period a",
+			func() *PeriodCollection {
+				return pc
+			},
+			time.Date(2018, 12, 5, 0, 0, 0, 0, time.UTC),
+			[]interface{}{"a"},
+		}, {
+			"2018-12-05 12:00 contained in period a",
+			func() *PeriodCollection {
+				return pc
+			},
+			time.Date(2018, 12, 5, 12, 0, 0, 0, time.UTC),
+			[]interface{}{"a"},
+		}, {
+			"2018-12-07 00:00 contained in period b",
+			func() *PeriodCollection {
+				return pc
+			},
+			time.Date(2018, 12, 7, 0, 0, 0, 0, time.UTC),
+			[]interface{}{"b"},
+		}, {
+			"2018-12-07 16:00 contained in periods b and c",
+			func() *PeriodCollection {
+				return pc
+			},
+			time.Date(2018, 12, 7, 16, 0, 0, 0, time.UTC),
+			[]interface{}{"b", "c"},
+		}, {
+			"2018-12-04 00:00 not contained in any periods",
+			func() *PeriodCollection {
+				return pc
+			},
+			time.Date(2018, 12, 4, 0, 0, 0, 0, time.UTC),
+			[]interface{}{},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			collection := test.setupCollection()
+			assert.Equal(t, test.expectedContents, collection.ContainsTime(test.time))
 		})
 	}
 }

--- a/period_collection_test.go
+++ b/period_collection_test.go
@@ -1527,7 +1527,7 @@ func TestPeriodCollection_ContainsTime(t *testing.T) {
 			for i, p := range test.periods {
 				require.NoError(t, pc.Insert(i, p, nil))
 			}
-			assert.Equal(t, test.expectedOutcome, pc.ContainsTime(test.query))
+			assert.Equal(t, test.expectedOutcome, pc.AnyContainsTime(test.query))
 		})
 	}
 }

--- a/period_collection_test.go
+++ b/period_collection_test.go
@@ -6,7 +6,7 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by selectNode law or agreed to in writing, software
+// Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and


### PR DESCRIPTION
This renames the existing ContainsTime method to AnyContainsTime and adds new implementation for ContainsTime that will return all nodes with periods that contain the specified time. I did it this way so that the names of the contains time methods are analogous to the intersecting methods.