### PR TITLE
DST spring ahead fix

### DIFF
--- a/continuous_period.go
+++ b/continuous_period.go
@@ -85,6 +85,11 @@ func (cp ContinuousPeriod) AtDate(d time.Time) Period {
 			offset = time.Duration(HoursInDay*(dLoc.Weekday()-(DaysInWeek+cp.StartDOW))) * time.Hour
 		}
 		startDay = dLoc.Add(-offset)
+		// Adjust the start day offset if there is a timezone difference between start day and the queried time.
+		_, dLocOffset := dLoc.Zone()
+		_, startDayOffset := startDay.Zone()
+		startDay = startDay.Add(time.Duration(dLocOffset-startDayOffset) * time.Second)
+
 		offsetDate.Start = time.Date(startDay.Year(), startDay.Month(), startDay.Day(), 0, 0, 0, 0, cp.Location)
 		offsetDate.Start = offsetDate.Start.Add(cp.Start)
 	} else {

--- a/continuous_period_test.go
+++ b/continuous_period_test.go
@@ -105,11 +105,17 @@ func TestContinuousPeriod_AtDate(t *testing.T) {
 			NewContinuousPeriod(6*time.Hour, 0, time.Friday, time.Monday, chiTz),
 			time.Date(2019, 3, 9, 0, 0, 0, 0, chiTz),
 		}, {
-			"CP spanning dst spring forward returns correct period if start time of 0",
+			"CP spanning dst spring forward returns correct period if start time is 0",
 			// DST change on 2020-03-10
 			NewPeriod(time.Date(2020, 3, 8, 0, 0, 0, 0, chiTz), time.Date(2020, 3, 13, 0, 0, 0, 0, chiTz)),
 			NewContinuousPeriod(0, 0, time.Sunday, time.Friday, chiTz),
 			time.Date(2020, 3, 12, 0, 0, 0, 0, chiTz),
+		}, {
+			"CP spanning dst fallback returns correct period if start time is 0",
+			// DST change on 2019-11-03
+			NewPeriod(time.Date(2019, 11, 3, 0, 0, 0, 0, chiTz), time.Date(2019, 11, 8, 0, 0, 0, 0, chiTz)),
+			NewContinuousPeriod(0, 0, time.Sunday, time.Friday, chiTz),
+			time.Date(2019, 11, 2, 0, 0, 0, 0, chiTz),
 		},
 	}
 	for _, test := range tests {

--- a/continuous_period_test.go
+++ b/continuous_period_test.go
@@ -104,6 +104,12 @@ func TestContinuousPeriod_AtDate(t *testing.T) {
 			NewPeriod(time.Date(2019, 3, 8, 6, 0, 0, 0, chiTz), time.Date(2019, 3, 11, 0, 0, 0, 0, chiTz)),
 			NewContinuousPeriod(6*time.Hour, 0, time.Friday, time.Monday, chiTz),
 			time.Date(2019, 3, 9, 0, 0, 0, 0, chiTz),
+		}, {
+			"CP spanning dst spring forward returns correct period if start time of 0",
+			// DST change on 2020-03-10
+			NewPeriod(time.Date(2020, 3, 8, 0, 0, 0, 0, chiTz), time.Date(2020, 3, 13, 0, 0, 0, 0, chiTz)),
+			NewContinuousPeriod(0, 0, time.Sunday, time.Friday, chiTz),
+			time.Date(2020, 3, 12, 0, 0, 0, 0, chiTz),
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
This fixes an issue where a continuous period spans the DST spring ahead time and the start time is set to 0.

As an example, let's say the continuous period is set for Sunday at 00:00 to Tuesday at 00:00. If a time for Monday is queried, an offset of 24 hours would be subtracted from the queried time to find the start day. Monday at 00:00 - 24 hours results in a start day/time of Saturday at 23:00 because of DST. This ultimately results in a return period of Saturday 00:00 to Monday 00:00 from the function.