### PR TITLE
add 12 hour display helper function for floating period durations

### DIFF
--- a/floating_period.go
+++ b/floating_period.go
@@ -15,6 +15,7 @@
 package periodic
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -153,4 +154,27 @@ func (fp FloatingPeriod) ContainsEnd(period Period) bool {
 // DayApplicable returns whether or not the given time falls on a day during which the floating period is applicable.
 func (fp FloatingPeriod) DayApplicable(t time.Time) bool {
 	return fp.Days.TimeApplicable(t, fp.Location)
+}
+
+// TwelveHourDisplay returns the 12-hour clock display string for the supplied duration, assuming that the duration
+// represents the time since midnight. The return string is in the format hh:mm AM/PM with leading 0's removed. It is
+// expected that the input duration is less than 24 hours.
+func TwelveHourDisplay(d time.Duration) string {
+	h := d / time.Hour
+	d -= h * time.Hour
+	m := d / time.Minute
+	ampm := "AM"
+	if h == 0 {
+		// d represents the midnight hour, so set h to 12
+		h = 12
+	} else if h == 12 {
+		// d represents the noon hour, so set ampm to 'PM'
+		ampm = "PM"
+	} else if h > 12 {
+		// d represents an afternoon hour, so h must be adjusted by 12
+		// and ampm must be set to 'PM'
+		h -= 12
+		ampm = "PM"
+	}
+	return fmt.Sprintf("%d:%02d %s", h, m, ampm)
 }

--- a/floating_period_test.go
+++ b/floating_period_test.go
@@ -606,3 +606,46 @@ func TestFloatingPeriodConstructionError_Error(t *testing.T) {
 	assert.Error(t, f)
 	assert.Equal(t, "e", f.Error())
 }
+
+func TestTwelveHourDisplay(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    time.Duration
+		expected string
+	}{
+		{
+			"morning time is converted",
+			10 * time.Hour,
+			"10:00 AM",
+		}, {
+			"afternoon time is converted",
+			23 * time.Hour,
+			"11:00 PM",
+		}, {
+			"12:00 PM is converted",
+			12 * time.Hour,
+			"12:00 PM",
+		}, {
+			"12:00 AM is converted",
+			0 * time.Hour,
+			"12:00 AM",
+		}, {
+			"single digit morning hour is converted",
+			5 * time.Hour,
+			"5:00 AM",
+		}, {
+			"single digit afternoon hour is converted",
+			14 * time.Hour,
+			"2:00 PM",
+		}, {
+			"input in seconds is converted",
+			29400 * time.Second,
+			"8:10 AM",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, TwelveHourDisplay(test.input))
+		})
+	}
+}


### PR DESCRIPTION
**Description**
Adds a helper function to return the 12-hour clock display for a time duration that starts at midnight.
