### PR TITLE
SEAR-3612 Fix linting errors for golangci-lint version 1.59.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 5m
+  timeout: 5m
   tests: true
 
 linters:
@@ -7,7 +7,7 @@ linters:
     - revive
     - gofmt
     - staticcheck
-    - vet
+    - govet
     - misspell
     - ineffassign
     - errcheck
@@ -16,5 +16,7 @@ linters:
 
 linters-settings:
   govet:
-    check-shadowing: true
+    settings:
+      shadow:
+        strict: true
     enable-all: true

--- a/floating_period_test.go
+++ b/floating_period_test.go
@@ -560,12 +560,12 @@ func TestNewFloatingPeriod(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			fp, err := NewFloatingPeriod(test.s, test.e, test.d, test.loc, false)
+			fp, fpErr := NewFloatingPeriod(test.s, test.e, test.d, test.loc, false)
 			if test.expectError {
-				require.Error(t, err)
+				require.Error(t, fpErr)
 				return
 			}
-			require.NoError(t, err)
+			require.NoError(t, fpErr)
 			assert.Equal(t, test.s, fp.Start)
 			assert.Equal(t, test.e, fp.End)
 			assert.Equal(t, test.d, fp.Days)


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/SEAR-3612

**Description**
This PR fixes all linting errors after upgrading our `golangci-lint` version to `1.59.1`. Depends on https://github.com/spothero/mdw/pull/370
